### PR TITLE
System cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/3scale/3scale-authorizer
+
+go 1.13
+
+require (
+	github.com/3scale/3scale-porta-go-client v0.0.3
+	github.com/orcaman/concurrent-map v0.0.0-20190314100340-2693aad1ed75
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/3scale/3scale-porta-go-client v0.0.3 h1:/jcEnBQqBDuJYQKvvmKUw6c4LoF4PWq57EAD4q6HiJ8=
+github.com/3scale/3scale-porta-go-client v0.0.3/go.mod h1:eXz9JDFNrbJRqJkDs39bMxO+m/L5pz51JMof3A8jQ1k=
+github.com/orcaman/concurrent-map v0.0.0-20190314100340-2693aad1ed75 h1:IV56VwUb9Ludyr7s53CMuEh4DdTnnQtEPLEgLyJ0kHI=
+github.com/orcaman/concurrent-map v0.0.0-20190314100340-2693aad1ed75/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
+github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6 h1:lNCW6THrCKBiJBpz8kbVGjC7MgdCGKwuvBgc7LoD6sw=
+github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=

--- a/pkg/system/v1/cache/system.go
+++ b/pkg/system/v1/cache/system.go
@@ -1,0 +1,187 @@
+// package cache provides constructs to enable caching of commonly required resources from the 3scale 'system' APIs
+package cache
+
+import (
+	"errors"
+	"sync/atomic"
+	"time"
+
+	"github.com/3scale/3scale-porta-go-client/client"
+	"github.com/orcaman/concurrent-map"
+)
+
+const (
+	// DefaultCacheTTL - Default time to wait before marking cached values expired
+	DefaultCacheTTL = time.Duration(time.Minute * 5)
+
+	// DefaultCacheRefreshInterval - Default interval at which background process should refresh items
+	DefaultCacheRefreshInterval = time.Duration(time.Minute * 3)
+
+	// DefaultCacheLimit - Default max number of items that can be stored in the cache at any time
+	// A negative value implies that there is no limit on the number of cached items
+	DefaultCacheLimit = -1
+)
+
+var now = time.Now
+
+// ConfigurationCache is the interface for managing a cache of `Proxy Config` resource(s)
+type ConfigurationCache interface {
+	// Get retrieves an element from the cache (if present) and returns a result, as well as a boolean value
+	// which identifies if the element was present or not
+	Get(key string) (Value, bool)
+	Set(key string, value Value)
+	Delete(key string)
+	FlushExpired()
+	Refresh()
+}
+
+// Value defines the value that must be stored in the cache
+type Value struct {
+	Item        client.ProxyConfig
+	expires     time.Time
+	refreshWith RefreshCb
+}
+
+// ConfigCache provides an in-memory solution which implements 'ConfigurationCache'
+type ConfigCache struct {
+	cache                cmap.ConcurrentMap
+	limit                int
+	refreshWorkerRunning int32
+	stopRefreshWorker    chan struct{}
+	ttl                  time.Duration
+}
+
+// RefreshCb defines a callback which can be used to refresh elements in the cache as required
+type RefreshCb func() (client.ProxyConfig, error)
+
+// NewConfigCache returns a ConfigCache configured with the provided inputs
+// It accepts a 'time to live' which will be the default value used to mark cached items as expired
+// Max entries limits the number of objects that can exist in the cache at a given time
+func NewConfigCache(ttl time.Duration, maxEntries int) *ConfigCache {
+	return &ConfigCache{
+		limit: maxEntries,
+		ttl:   ttl,
+		cache: cmap.New(),
+	}
+}
+
+// NewDefaultConfigCache returns a ConfigCache configured with the default values
+func NewDefaultConfigCache() *ConfigCache {
+	return &ConfigCache{
+		limit: DefaultCacheLimit,
+		ttl:   DefaultCacheTTL,
+		cache: cmap.New(),
+	}
+}
+
+// Get an element from the cache if it exists
+// The returned bool identifies if the element was present or not
+func (scp *ConfigCache) Get(key string) (Value, bool) {
+	value, ok := scp.cache.Get(key)
+	if !ok {
+		return Value{}, ok
+	}
+	return value.(Value), ok
+}
+
+// Set an item in the cache under the provided key
+// Returns an error if the max number of entries in the cache has been reached
+func (scp *ConfigCache) Set(key string, v Value) error {
+	if scp.limit < 0 || scp.cache.Count() < scp.limit {
+		scp.cache.Set(key, v)
+		return nil
+	}
+
+	return errors.New("error - cache is full, cannot add more elements")
+}
+
+// Delete an element from the cache
+func (scp *ConfigCache) Delete(key string) {
+	scp.cache.Remove(key)
+}
+
+// FlushExpired elements from the cache
+// Any element whose expiration date is passed the current time will be removed immediately
+func (scp *ConfigCache) FlushExpired() {
+	var forDeletion []string
+
+	scp.cache.IterCb(func(key string, v interface{}) {
+		item := v.(Value)
+		if item.isExpired() {
+			forDeletion = append(forDeletion, key)
+		}
+	})
+	for _, key := range forDeletion {
+		scp.Delete(key)
+	}
+}
+
+// Refresh elements in the cache using the provided callback
+// Elements whose callback returns an error will not be refreshed but wil be left in the cache to expire
+func (scp *ConfigCache) Refresh() {
+	refreshItems := make(map[string]Value)
+
+	scp.cache.IterCb(func(key string, v interface{}) {
+		item := v.(Value)
+		if item.refreshWith != nil {
+			resp, err := item.refreshWith()
+			if err != nil {
+				return
+			}
+
+			value := Value{
+				Item:        resp,
+				expires:     scp.getExpiryTime(),
+				refreshWith: item.refreshWith,
+			}
+			refreshItems[key] = value
+		}
+	})
+	for k, v := range refreshItems {
+		scp.Set(k, v)
+	}
+}
+
+// RunRefreshWorker at increments provided by the interval
+// At each interval, elements will be refreshed. See 'Refresh()'
+func (scp *ConfigCache) RunRefreshWorker(interval time.Duration, stop chan struct{}) error {
+	if !atomic.CompareAndSwapInt32(&scp.refreshWorkerRunning, 0, 1) {
+		return errors.New("worker has already been started")
+	}
+
+	scp.stopRefreshWorker = stop
+	ticker := time.NewTicker(interval)
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				scp.Refresh()
+			case <-stop:
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+func (scp *ConfigCache) getExpiryTime() time.Time {
+	return now().Add(scp.ttl)
+}
+
+// SetExpiry time on a value to override the default expiry time set by the caching implementation
+func (v Value) SetExpiry(t time.Time) Value {
+	v.expires = t
+	return v
+}
+
+// SetRefreshCallback, the callback that will be used to attempt to refresh an element when requested
+// Retry and backoff logic should be implemented in the callback as required.
+func (v Value) SetRefreshCallback(fn RefreshCb) Value {
+	v.refreshWith = fn
+	return v
+}
+
+func (v Value) isExpired() bool {
+	return now().After(v.expires)
+}

--- a/pkg/system/v1/cache/system_test.go
+++ b/pkg/system/v1/cache/system_test.go
@@ -1,0 +1,154 @@
+package cache
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/3scale/3scale-porta-go-client/client"
+)
+
+func TestConfigCache_Get(t *testing.T) {
+	cc := NewDefaultConfigCache()
+	if _, ok := cc.Get("non-existent"); ok {
+		t.Error("expected function to return false when item not present")
+	}
+
+	cc.Set("test", Value{Item: client.ProxyConfig{ID: 5}})
+	v, ok := cc.Get("test")
+	if !ok {
+		t.Error("expected element to be present")
+	}
+
+	if v.Item.ID != 5 {
+		t.Error("unexpected value for ID of cached item")
+	}
+}
+
+func TestConfigCache_Set(t *testing.T) {
+	cc := NewDefaultConfigCache()
+	if cc.cache.Count() != 0 {
+		t.Error("expected new cache to be empty")
+	}
+
+	cc.Set("test", Value{Item: client.ProxyConfig{ID: 5}})
+	if cc.cache.Count() != 1 {
+		t.Error("expected cache to have only one element")
+	}
+
+	cc = NewConfigCache(time.Hour, -1)
+	err := cc.Set("any", Value{})
+	if err != nil {
+		t.Error("expected negative cache limit to be limitless")
+	}
+
+	cc = NewConfigCache(time.Hour, 0)
+	if err = cc.Set("any", Value{}); err == nil {
+		t.Error("expected zero cache limit to be restricted")
+	}
+
+	cc = NewConfigCache(time.Hour, 1)
+	if err = cc.Set("any", Value{}); err != nil {
+		t.Error("expected first insert to be a success")
+	}
+	if err = cc.Set("second", Value{}); err == nil {
+		t.Error("expected second insert to fail")
+	}
+}
+
+func TestConfigCache_Delete(t *testing.T) {
+	cc := NewDefaultConfigCache()
+	cc.Set("test", Value{Item: client.ProxyConfig{ID: 5}})
+	if cc.cache.Count() != 1 {
+		t.Error("expected cache to have only one element")
+	}
+
+	cc.Delete("test")
+	if cc.cache.Count() != 0 {
+		t.Error("expected cache to have no elements post deletion")
+	}
+}
+
+func TestConfigCache_FlushExpired(t *testing.T) {
+	cc := NewDefaultConfigCache()
+
+	yesterday := time.Hour * -24
+	v := Value{Item: client.ProxyConfig{ID: 5}}.SetExpiry(time.Now().Add(yesterday))
+
+	cc.Set("test", v)
+	if cc.cache.Count() != 1 {
+		t.Error("expected cache to have only one element")
+	}
+
+	cc.FlushExpired()
+	if cc.cache.Count() != 0 {
+		t.Error("expected cache to be empty after flushing expired items")
+	}
+}
+
+func TestConfigCache_Refresh(t *testing.T) {
+	cc := NewDefaultConfigCache()
+
+	// test value unmodified during error
+	refreshCb := func() (client.ProxyConfig, error) {
+		return client.ProxyConfig{}, http.ErrHandlerTimeout
+	}
+	v := Value{Item: client.ProxyConfig{ID: 5}}.SetRefreshCallback(refreshCb)
+	cc.Set("test", v)
+	cc.Refresh()
+	updatedV, ok := cc.Get("test")
+	if !ok {
+		t.Error("expected element to be present")
+	}
+	if updatedV.Item.ID != 5 {
+		t.Error("unexpected result. expected callback to have modified ID when refreshing")
+	}
+
+	// test refresh success
+	refreshCb = func() (client.ProxyConfig, error) {
+		return client.ProxyConfig{ID: 6}, nil
+	}
+	v = Value{Item: client.ProxyConfig{ID: 5}}.SetRefreshCallback(refreshCb)
+
+	cc.Set("test", v)
+	cc.Refresh()
+	updatedV, ok = cc.Get("test")
+	if !ok {
+		t.Error("expected element to be present")
+	}
+	if updatedV.Item.ID != 6 {
+		t.Error("unexpected result. expected callback to have modified ID when refreshing")
+	}
+}
+
+func TestConfigCache_RunRefreshWorker(t *testing.T) {
+	// test error on startup
+	cc := NewDefaultConfigCache()
+	cc.refreshWorkerRunning = 1
+	if err := cc.RunRefreshWorker(time.Hour, nil); err == nil {
+		t.Error("expected error as worker had been marked as started")
+	}
+
+	cc = NewDefaultConfigCache()
+	done := make(chan bool)
+	refreshCb := func() (client.ProxyConfig, error) {
+		done <- true
+		return client.ProxyConfig{ID: 0}, nil
+	}
+
+	v := Value{}.SetRefreshCallback(refreshCb)
+	cc.Set("test", v)
+	stop := make(chan struct{})
+	if err := cc.RunRefreshWorker(time.Millisecond, stop); err != nil {
+		t.Errorf("unexpected error when running refresh worker")
+	}
+
+	<-time.After(time.Second)
+	success := <-done
+	if !success {
+		t.Error("expected refresh worker to have been called an callback to be executed")
+	}
+
+	close(stop)
+
+}


### PR DESCRIPTION
This code implements caching logic for system proxy configuration. Using `concurrent-map` package as a datastore for the cache as it is likely we will be using that elsewhere also