### PR TITLE
system: Set default TTL on cached item if zero value

### DIFF
--- a/pkg/system/v1/cache/system.go
+++ b/pkg/system/v1/cache/system.go
@@ -88,6 +88,9 @@ func (scp *ConfigCache) Get(key string) (Value, bool) {
 // Returns an error if the max number of entries in the cache has been reached
 func (scp *ConfigCache) Set(key string, v Value) error {
 	if scp.limit < 0 || scp.cache.Count() < scp.limit {
+		if v.expires.IsZero() {
+			v.expires = scp.getExpiryTime()
+		}
 		scp.cache.Set(key, v)
 		return nil
 	}


### PR DESCRIPTION
The cached Value exposes a SetExpiry function to set an unexported
field. However if this has not been set by the caller, when the item is
placed in the cache during a Set operation, we now default to setting
this value from the struct config.