### PR TITLE
authorizer: Clone http transport before setting the RoundTrip

### DIFF
--- a/pkg/authorizer/authorizer.go
+++ b/pkg/authorizer/authorizer.go
@@ -108,14 +108,18 @@ func NewManager(
 	reporter *MetricsReporter,
 ) *Manager {
 
-	builder := ClientBuilder{httpClient: http.DefaultClient}
+	baseTransport := client.Transport.(*http.Transport).Clone()
+	builder := ClientBuilder{httpClient: client}
 
 	if reporter == nil {
 		reporter = &MetricsReporter{}
 	}
 
 	if reporter.ReportMetrics && reporter.ResponseCB != nil {
-		builder.httpClient.Transport = &MetricsTransport{client: builder.httpClient}
+		builder.httpClient.Transport = &MetricsRoundTripper{
+			proxied: baseTransport,
+			hook: reporter.ResponseCB,
+		}
 	}
 
 	if systemCache != nil {

--- a/pkg/authorizer/metrics.go
+++ b/pkg/authorizer/metrics.go
@@ -34,14 +34,14 @@ type MetricsReporter struct {
 	CacheHitCB    CacheHitHook
 }
 
-type MetricsTransport struct {
-	client *http.Client
-	hook   ResponseHook
+type MetricsRoundTripper struct {
+	proxied http.RoundTripper
+	hook    ResponseHook
 }
 
-func (mt *MetricsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+func (mt *MetricsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	start := time.Now()
-	resp, err := mt.client.Transport.RoundTrip(req)
+	resp, err := mt.proxied.RoundTrip(req)
 	if err != nil {
 		return resp, err
 	}


### PR DESCRIPTION
When we wanted to engage metrics, we used the RoundTripper interface to fetch information from the request response cycle. However we needed to do a deep copy on the transport prior to setting it on the metrics implementation as this was causing an infinite loop with the same transport being reused and proxied.