### PR TITLE
Support OAuth endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/3scale/3scale-authorizer
 go 1.13
 
 require (
-	github.com/3scale/3scale-go-client v0.4.1-0.20200527144043-59f1bbdf5147
+	github.com/3scale/3scale-go-client v0.5.1
 	github.com/3scale/3scale-porta-go-client v0.0.4-0.20200617082049-6c84693ca4c0
+	github.com/oleiade/lane v1.0.1 // indirect
 	github.com/orcaman/concurrent-map v0.0.0-20190314100340-2693aad1ed75
-	gopkg.in/oleiade/lane.v1 v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,17 @@
 github.com/3scale/3scale-go-client v0.4.1-0.20200527144043-59f1bbdf5147 h1:cBZw0DYo0F04Fw7TbFoeEqPMvMLiHn90AuESCUSIz+I=
 github.com/3scale/3scale-go-client v0.4.1-0.20200527144043-59f1bbdf5147/go.mod h1:mIpZ1swgfSBVN7JqvxtY0AC9QaLHmhGvGsP9P71ZilQ=
+github.com/3scale/3scale-go-client v0.5.1-0.20210605082514-e023f4902057 h1:7ESxVHap7RrBLkvp7iptxto6kBo5rqMQrh2Bnsim/HU=
+github.com/3scale/3scale-go-client v0.5.1-0.20210605082514-e023f4902057/go.mod h1:mIpZ1swgfSBVN7JqvxtY0AC9QaLHmhGvGsP9P71ZilQ=
+github.com/3scale/3scale-go-client v0.5.1-0.20210614153756-b7a437245b13 h1:AI1FqtWTi7pq8IF3/rSXX53FyizEGmbwFsxWt6QNpS4=
+github.com/3scale/3scale-go-client v0.5.1-0.20210614153756-b7a437245b13/go.mod h1:mIpZ1swgfSBVN7JqvxtY0AC9QaLHmhGvGsP9P71ZilQ=
+github.com/3scale/3scale-go-client v0.5.1 h1:V7B4HCOUV4h+S4PbG7ubVBRMYgBOavsD8nPmu0ywbDk=
+github.com/3scale/3scale-go-client v0.5.1/go.mod h1:mIpZ1swgfSBVN7JqvxtY0AC9QaLHmhGvGsP9P71ZilQ=
 github.com/3scale/3scale-porta-go-client v0.0.4-0.20200617082049-6c84693ca4c0 h1:LV6FAgkWb/M6Sr3qTgP0mmvmKzKheIb8TU/7dfKRNvU=
 github.com/3scale/3scale-porta-go-client v0.0.4-0.20200617082049-6c84693ca4c0/go.mod h1:nUbuVh0fU2rs/lJfowmS5YhEk2tQoybL4htDIdxxMaM=
+github.com/oleiade/lane v1.0.0 h1:cv31GhI+iQjTgn9dfeC8mBvUbue7YDyGMrda8L7+3yo=
+github.com/oleiade/lane v1.0.0/go.mod h1:IyTkraa4maLfjq/GmHR+Dxb4kCMtEGeb+qmhlrQ5Mk4=
+github.com/oleiade/lane v1.0.1 h1:hXofkn7GEOubzTwNpeL9MaNy8WxolCYb9cInAIeqShU=
+github.com/oleiade/lane v1.0.1/go.mod h1:IyTkraa4maLfjq/GmHR+Dxb4kCMtEGeb+qmhlrQ5Mk4=
 github.com/orcaman/concurrent-map v0.0.0-20190314100340-2693aad1ed75 h1:IV56VwUb9Ludyr7s53CMuEh4DdTnnQtEPLEgLyJ0kHI=
 github.com/orcaman/concurrent-map v0.0.0-20190314100340-2693aad1ed75/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 gopkg.in/oleiade/lane.v1 v1.0.0 h1:Xs7/GTdnZNGuuXV7z8gTrHoHEeHdCnhuNXm4n0UpxjY=

--- a/pkg/authorizer/authorizer_test.go
+++ b/pkg/authorizer/authorizer_test.go
@@ -558,11 +558,19 @@ func (mbc mockBackendClient) Authorize(request threescale.Request) (*threescale.
 	panic("implement me")
 }
 
+func (mbc mockBackendClient) OauthAuthorize(request threescale.Request) (*threescale.AuthorizeResult, error) {
+	panic("implement me")
+}
+
 func (mbc mockBackendClient) AuthRep(request threescale.Request) (*threescale.AuthorizeResult, error) {
 	if mbc.withAuthRepErr {
 		return nil, fmt.Errorf("arbitrary error")
 	}
 	return mbc.withAuthResponse, nil
+}
+
+func (mbc mockBackendClient) OauthAuthRep(request threescale.Request) (*threescale.AuthorizeResult, error) {
+	return mbc.AuthRep(request)
 }
 
 func (mockBackendClient) Report(request threescale.Request) (*threescale.ReportResult, error) {

--- a/pkg/backend/v1/backend_test.go
+++ b/pkg/backend/v1/backend_test.go
@@ -1701,8 +1701,16 @@ func (mc *mockRemoteClient) Authorize(request threescale.Request) (*threescale.A
 	return mc.authRes, mc.err
 }
 
+func (mc *mockRemoteClient) OauthAuthorize(request threescale.Request) (*threescale.AuthorizeResult, error) {
+	return mc.Authorize(request)
+}
+
 func (mc *mockRemoteClient) AuthRep(request threescale.Request) (*threescale.AuthorizeResult, error) {
 	return mc.authRes, mc.err
+}
+
+func (mc *mockRemoteClient) OauthAuthRep(request threescale.Request) (*threescale.AuthorizeResult, error) {
+	return mc.AuthRep(request)
 }
 
 func (mc *mockRemoteClient) Report(request threescale.Request) (*threescale.ReportResult, error) {

--- a/pkg/backend/v1/queue.go
+++ b/pkg/backend/v1/queue.go
@@ -1,7 +1,7 @@
 package backend
 
 import (
-	"gopkg.in/oleiade/lane.v1"
+	"github.com/oleiade/lane"
 )
 
 // dequeue is a head-tail linked list data structure provided for working with Application(s)


### PR DESCRIPTION
This updates our dependency of 3scale-go-client to pick up a version that can work with oauth_auth*.xml endpoints, and introduces using such endpoints when the service is declared as "oauth".

For more information see https://github.com/3scale/apisonator/pull/280.